### PR TITLE
PRO-6775: Sass resolver for modules alias

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 * Adds support for `synthetic` entrypoints, that will only process the entrypoint `prologue`.
 * Adds support for `Modules/...` alias for the public builds (Webpack BC). 
 * Our Vite alias plugin now throws with an useful error message when `Modules/` alias resolver fails.
+* Adds sass resolver for `Modules/` alias. It works for both public and private builds in exactly the same way as the JS resolver.
 
 ### Fixes
 

--- a/lib/vite-plugin-apostrophe-alias.mjs
+++ b/lib/vite-plugin-apostrophe-alias.mjs
@@ -1,4 +1,5 @@
 import { join } from 'node:path';
+import { pathToFileURL } from 'node:url';
 
 /**
  * Resolve `apos` and `public` builds alias `Modules/`. The `sourceRoot` option
@@ -26,30 +27,37 @@ export default function VitePluginApos({ sourceRoot, id } = {}) {
   return {
     name: 'vite-plugin-apostrophe-alias',
 
+    config() {
+      return {
+        css: {
+          preprocessorOptions: {
+            scss: {
+              importers: [ { findFileUrl } ]
+            }
+          }
+        }
+      };
+    },
+
     async resolveId(source, importer, options) {
       if (!source.startsWith('Modules/')) {
         return null;
       }
-      const chunks = source.replace('Modules/', '').split('/');
-      let moduleName = chunks.shift();
-      if (moduleName.startsWith('@')) {
-        moduleName += '/' + chunks.shift();
-      }
-      const absPath = join(
-        pluginOptions.sourceRoot,
-        moduleName,
-        pluginOptions.id,
-        ...chunks
-      );
+
+      const {
+        absolutePath, moduleName, chunks
+      } = parseModuleAlias(source, pluginOptions);
+
       const resolved = await this.resolve(
-        absPath,
+        absolutePath,
         importer,
         options
       );
+
       if (!resolved) {
         // For internal debugging purposes
         this.warn(
-          `Resolve attempt failed: "${source}" -> "${absPath}"`
+          `Resolve attempt failed: "${source}" -> "${absolutePath}"`
         );
         // For user-facing error messages
         this.error(
@@ -60,7 +68,38 @@ export default function VitePluginApos({ sourceRoot, id } = {}) {
           'https://docs.apostrophecms.org/guide/vite.html#resolve-alias-errors'
         );
       }
+
       return resolved;
     }
+  };
+
+  // Sass FileImporter
+  function findFileUrl(url) {
+    if (url.startsWith('Modules/')) {
+      const { absolutePath } = parseModuleAlias(url, pluginOptions);
+
+      return pathToFileURL(absolutePath);
+    }
+    return null;
+  }
+}
+
+function parseModuleAlias(source, pluginOptions) {
+  const chunks = source.replace('Modules/', '').split('/');
+  let moduleName = chunks.shift();
+  if (moduleName.startsWith('@')) {
+    moduleName += '/' + chunks.shift();
+  }
+  const absolutePath = join(
+    pluginOptions.sourceRoot,
+    moduleName,
+    pluginOptions.id,
+    ...chunks
+  );
+
+  return {
+    moduleName,
+    absolutePath,
+    chunks
   };
 }


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## Summary

* Adds sass resolver for `Modules/` alias. It works for both public and private builds in exactly the same way as the JS resolver.

## What are the specific steps to test this change?

Using this in any sass file:
```
@import "Modules/asset/scss/variables";
```

Should result in path resolved to path resolved to original file in e.g. `./modules/asset/ui/src/scss/_variables.scss` or `./modules/asset/ui/apos/scss/_variables.scss` (depending on what build the caller is running in).

## What kind of change does this PR introduce?
*(Check at least one)*

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Build-related changes
- [ ] Other

## Make sure the PR fulfills these requirements:

- [x] It includes a) the existing issue ID being resolved, b) a convincing reason for adding this feature, or c) a clear description of the bug it resolves
- [x] The changelog is updated
- [ ] Related documentation has been updated
- [ ] Related tests have been updated

If adding a new feature without an already open issue, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**
