### PR TITLE
Add `@/` alias and fix config polution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 * Adds support for `Modules/...` alias for the public builds (Webpack BC). 
 * Our Vite alias plugin now throws with an useful error message when `Modules/` alias resolver fails.
 * Adds sass resolver for `Modules/` alias. It works for both public and private builds in exactly the same way as the JS resolver.
+* Adds alias `@/` for all builds, that points to the project build source root. This works for both JS and SCSS.
 
 ### Fixes
 

--- a/README.md
+++ b/README.md
@@ -162,6 +162,59 @@ bundler: 'webpack' // Only visible when using webpack
 
 You can combine these options to precisely control when your component appears. For example, to show a component only when using Vite with HMR active, you would use both `when: 'hmr'` and `bundler: 'vite'`.
 
+## Provided Vite Configuration
+
+While the `apos` build (the code living in every module `ui/apos` directory) is fully preconfigured and doesn't allow for customization, the `public` build (the code imported within `ui/src/` ) is fully customizable and contains a minimal configuration to get you started:
+- A PostCSS plugin to handle core features as "Breakpoint Preview" (when enabled)
+- `Modules/` alias to simplify module within the same build 
+- `@/` alias to allow easy access to cross-module and cross-build source code
+
+### Pre-configured Aliases
+
+`Modules/` alias is available for both public and admin UI builds and allows you to import modules in your project without worrying about the relative path, but restricts you to only sources inside of `ui/src` directories.
+
+```javascript
+// Current file: modules/another-module/ui/src/index.js
+// Actual import path: modules/my-module/ui/src/lib/utils.js
+import utils from 'Modules/my-module/lib/utils.js';
+```
+
+`@/` alias is available for both public and admin UI builds and allows you to import files from the entire project source code.
+
+```javascript
+// Current file: any file in any module inside of the `ui/` folder
+// Actual path: modules/my-module/ui/src/lib/utils.js
+import utils from '@/modules/my-module/src/lib/utils.js';
+
+// Actual path: modules/my-module/ui/apos/mixins/SomeMixin.js
+import SomeMixin from '@/modules/my-module/apos/mixins/SomeMixin.js';
+```
+
+## Configuring Your Code Editor
+
+Every editor, that understands the `jsconfig.json` or `tsconfig.json` file, can be configured to understand the `@/` alias provided by this module. Here is an example of a `jsconfig.json` file that you can place in your project root:
+
+```json
+{
+  "compilerOptions": {
+    "baseUrl": "./apos-build/@apostrophecms/vite/default",
+    "paths": {
+      "@/*": ["./src/*"]
+    },
+    "module": "ESNext",
+    "moduleResolution": "bundler"
+  },
+  "exclude": [
+    "apos-build/@apostrophecms/vite/default/dist",
+    "node_modules",
+    "public",
+    "data"
+  ]
+}
+```
+
+> Note: If you change your project asset namespace you have to adjust the `baseUrl` and `exclude` path accordingly. For example, if your project namespace is `my-namespace`, the `baseUrl` should be `./apos-build/@apostrophecms/vite/my-namespace`.
+
 ## Extending the Vite Configuration
 
 You can customize the Vite configuration for your ApostropheCMS project in two ways:

--- a/README.md
+++ b/README.md
@@ -190,6 +190,8 @@ import utils from '@/modules/my-module/src/lib/utils.js';
 import SomeMixin from '@/modules/my-module/apos/mixins/SomeMixin.js';
 ```
 
+> Warning: You gain access to `public` builds from within the `apos` build, and vice versa, when using the `@/` alias. You should use it with caution, because it might lead to situations where imports are not resolved correctly. This would happen if the imported file (or its deep imports) contains `Modules/` aliased imports. In other hand `@/` is more developer friendly, allows auto-completion and is more intuitive and readable. Be sure to include mostly sources from your current build and ensure no imported sources contain `Modules/` aliased imports when cross-importing from another build.
+
 ## Configuring Your Code Editor
 
 Every editor, that understands the `jsconfig.json` or `tsconfig.json` file, can be configured to understand the `@/` alias provided by this module. Here is an example of a `jsconfig.json` file that you can place in your project root:
@@ -213,7 +215,7 @@ Every editor, that understands the `jsconfig.json` or `tsconfig.json` file, can 
 }
 ```
 
-> Note: If you change your project asset namespace you have to adjust the `baseUrl` and `exclude` path accordingly. For example, if your project namespace is `my-namespace`, the `baseUrl` should be `./apos-build/@apostrophecms/vite/my-namespace`.
+> Note: If you change your project asset namespace you have to adjust the `baseUrl` and `exclude` path accordingly. For example, if your project namespace is `my-namespace`, the `baseUrl` should be `./apos-build/@apostrophecms/vite/my-namespace` and the `exclude` path - `apos-build/@apostrophecms/vite/my-namespace/dist`.
 
 ## Extending the Vite Configuration
 
@@ -265,6 +267,7 @@ The configuration format follows the standard [Vite configuration options](https
 
 ### Hot Module Replacement
 - HMR only monitors existing `anyModule/ui` directories. If you add a new `ui` directory to a module, restart the server to enable HMR for that module. With default ApostropheCMS starter kits using `nodemon`, simply type `rs` in the terminal and press Enter.
+- The `apos` HMR won't work when the `public` build contains Vue sources (transformed by the `@vitejs/plugin-vue` plugin). The HMR for the `public` build should still work as expected. The problem is related to the fact that the page would contains two Vue instances (core and reactive) instances, which is not currently supported. We are researching solutions to this issue.
 
 ### Public Assets
 - Changes to `ui/public` directories don't trigger HMR or page reloads as they require a process restart

--- a/README.md
+++ b/README.md
@@ -164,14 +164,14 @@ You can combine these options to precisely control when your component appears. 
 
 ## Provided Vite Configuration
 
-While the `apos` build (the code living in every module `ui/apos` directory) is fully preconfigured and doesn't allow for customization, the `public` build (the code imported within `ui/src/` ) is fully customizable and contains a minimal configuration to get you started:
-- A PostCSS plugin to handle core features as "Breakpoint Preview" (when enabled)
+While the `apos` build (the code living in the`ui/apos/` directory of every module) is fully preconfigured and doesn't allow for customization, the `public` build (the code imported within `ui/src/` ) is fully customizable and contains a minimal configuration to get you started:
+- A PostCSS plugin to handle core features such as "Breakpoint Preview" (when enabled)
 - `Modules/` alias to simplify module within the same build 
 - `@/` alias to allow easy access to cross-module and cross-build source code
 
 ### Pre-configured Aliases
 
-`Modules/` alias is available for both public and admin UI builds and allows you to import modules in your project without worrying about the relative path, but restricts you to only sources inside of `ui/src` directories.
+The `Modules/` alias is available for both public and admin UI builds and allows you to import modules in your project without worrying about the relative path, but restricts you to only sources inside of `ui/src/` directories.
 
 ```javascript
 // Current file: modules/another-module/ui/src/index.js
@@ -190,7 +190,7 @@ import utils from '@/some-module/src/lib/utils.js';
 import SomeMixin from '@/some-module/apos/mixins/SomeMixin.js';
 ```
 
-> Warning: You gain access to `public` builds from within the `apos` build, and vice versa, when using the `@/` alias. You should use it with caution, because it might lead to situations where imports are not resolved correctly. This would happen if the imported file (or its deep imports) contains `Modules/` aliased imports. In other hand `@/` is more developer friendly, allows auto-completion and is more intuitive and readable. Be sure to include mostly sources from your current build and ensure no imported sources contain `Modules/` aliased imports when cross-importing from another build.
+> Warning: You gain access to `public` builds from within the `apos` build, and vice versa, when using the `@/` alias. You should use it with caution, because it might lead to situations where imports are not resolved correctly. This would happen if the imported file (or its deep imports) contains `Modules/` aliased imports. On the other hand, `@/` is more developer friendly, allows auto-completion, and is more intuitive and readable. Be sure to include mostly sources from your current build and ensure no imported sources contain `Modules/` aliased imports when cross-importing from another build.
 
 ### Importing Static Assets and Sass
 
@@ -326,7 +326,7 @@ The configuration format follows the standard [Vite configuration options](https
 
 ### Hot Module Replacement
 - HMR only monitors existing `anyModule/ui` directories. If you add a new `ui` directory to a module, restart the server to enable HMR for that module. With default ApostropheCMS starter kits using `nodemon`, simply type `rs` in the terminal and press Enter.
-- The `apos` HMR won't work when the `public` build contains Vue sources (transformed by the `@vitejs/plugin-vue` plugin). The HMR for the `public` build should still work as expected. The problem is related to the fact that the page would contains two Vue instances (core and reactive) instances, which is not currently supported. We are researching solutions to this issue.
+- The `apos` HMR won't work when the `public` build contains Vue sources (transformed by the `@vitejs/plugin-vue` plugin). The HMR for the `public` build should still work as expected. The problem is related to the fact that the page would contain two Vue instances (core and reactive) instances, which is not currently supported. We are researching solutions to this issue.
 
 ### Public Assets
 - Changes to `ui/public` directories don't trigger HMR or page reloads as they require a process restart

--- a/lib/internals.js
+++ b/lib/internals.js
@@ -82,10 +82,9 @@ module.exports = (self) => {
 
       self.printLabels('apos', true);
       const { build, config } = await self.getViteBuild('apos', options);
+      self.printDebug('build-apos', { viteConfig: config });
       await build(config);
       self.printLabels('apos', false);
-
-      self.printDebug('build-apos', { viteConfig: config });
 
       return Date.now();
     },
@@ -104,10 +103,9 @@ module.exports = (self) => {
       }
       self.printLabels('public', true);
       const { build, config } = await self.getViteBuild('public', options);
+      self.printDebug('build-public', { viteConfig: config });
       await build(config);
       self.printLabels('public', false);
-
-      self.printDebug('build-public', { viteConfig: config });
     },
 
     // Create an entrypoint configuration for the vite client.
@@ -968,12 +966,15 @@ module.exports = (self) => {
 
         // The `apos.vite.config.js` at the project root can be used to extend
         // the public config.
-        const userConfig = (await vite.loadConfigFromFile(
-          configEnv,
-          self.userConfigFile,
-          self.apos.rootDir,
-          'silent'
-        ))?.config || {};
+        const userConfig = self.userConfigFile
+          ? (await vite.loadConfigFromFile(
+            configEnv,
+            self.userConfigFile,
+            self.apos.rootDir,
+            'silent'
+          ))?.config || {}
+          : {};
+
         merged = vite.mergeConfig(merged, userConfig);
 
         return merged;

--- a/lib/vite-plugin-apostrophe-alias.mjs
+++ b/lib/vite-plugin-apostrophe-alias.mjs
@@ -26,7 +26,7 @@ export default function VitePluginApos({ sourceRoot, id } = {}) {
 
   return {
     name: 'vite-plugin-apostrophe-alias',
-
+    enforce: 'pre',
     config() {
       return {
         css: {
@@ -34,6 +34,11 @@ export default function VitePluginApos({ sourceRoot, id } = {}) {
             scss: {
               importers: [ { findFileUrl } ]
             }
+          }
+        },
+        resolve: {
+          alias: {
+            '@': `${sourceRoot}/`
           }
         }
       };


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## Summary

- `@/` alias that resolves in the same way no matter the current build
- Fix `vite.config.js` being loaded if no `apos.vite.config.js` is present.

## What are the specific steps to test this change?

-

## What kind of change does this PR introduce?
*(Check at least one)*

- [x] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Build-related changes
- [ ] Other

## Make sure the PR fulfills these requirements:

- [x] It includes a) the existing issue ID being resolved, b) a convincing reason for adding this feature, or c) a clear description of the bug it resolves
- [x] The changelog is updated
- [x] Related documentation has been updated
- [x] Related tests have been updated

If adding a new feature without an already open issue, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**
