### PR TITLE
Pro 6901 mobile preview broken UI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## UNRELESED
+
+### Fixes
+
+* Uses `postcss-viewport-to-container-toggle` plugin only on `public` builds to avoid breaking apos UI out of `apos-refreshable`.
+
 ## 1.0.0-beta.2 (2024-11-20)
 
 ### Adds

--- a/lib/internals.js
+++ b/lib/internals.js
@@ -1004,10 +1004,10 @@ module.exports = (self) => {
           } = await postcssrc({}, self.apos.rootDir);
           postcssPlugins.push(...plugins);
         } catch (err) { /* Project has no postcss config file */ }
-      }
 
-      if (enablePostcssViewport) {
-        postcssPlugins.push(postcssViewportToContainerToggle(postcssViewportOptions));
+        if (enablePostcssViewport) {
+          postcssPlugins.push(postcssViewportToContainerToggle(postcssViewportOptions));
+        }
       }
 
       if (id === 'apos') {
@@ -1049,3 +1049,4 @@ module.exports = (self) => {
     }
   };
 };
+

--- a/lib/internals.js
+++ b/lib/internals.js
@@ -1049,4 +1049,3 @@ module.exports = (self) => {
     }
   };
 };
-


### PR DESCRIPTION
[PRO-6901](https://linear.app/apostrophecms/issue/PRO-6901/apostrophe-manager-and-edit-modals-are-broken-in-testbed-environments)

## Summary

Fixes APOS broken UI when mobile preview is active.

## What are the specific steps to test this change?

Can play, open modals, use apos UI when mobile preview is active, it should work well.

## What kind of change does this PR introduce?

- [X] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Build-related changes
- [ ] Other

## Make sure the PR fulfills these requirements:

- [X] It includes a) the existing issue ID being resolved, b) a convincing reason for adding this feature, or c) a clear description of the bug it resolves
- [X] The changelog is updated
- [ ] Related documentation has been updated
- [ ] Related tests have been updated