### PR TITLE
Add pnpm resolve plugin

### DIFF
--- a/lib/vite-apos-config.js
+++ b/lib/vite-apos-config.js
@@ -3,6 +3,7 @@ module.exports = async ({
 }) => {
   const vue = await import('@vitejs/plugin-vue');
   const apos = await import('./vite-plugin-apostrophe-alias.mjs');
+  const pnpmResolve = await import('./vite-plugin-pnpm-resolve.mjs');
 
   /** @type {import('vite').UserConfig} */
   return {
@@ -25,7 +26,8 @@ module.exports = async ({
         id: 'apos',
         sourceRoot
       }),
-      vue.default()
+      vue.default(),
+      pnpmResolve.default()
     ],
     build: {
       chunkSizeWarningLimit: 2000,

--- a/lib/vite-plugin-pnpm-resolve.mjs
+++ b/lib/vite-plugin-pnpm-resolve.mjs
@@ -1,0 +1,54 @@
+import path from 'node:path';
+import fs from 'node:fs';
+import { createRequire } from 'node:module';
+
+const require = createRequire(import.meta.url);
+
+// Walk upward from a file until we find a package.json
+function findPkgRoot(startFile) {
+  let dir = path.dirname(startFile);
+  while (true) {
+    const pkg = path.join(dir, 'package.json');
+    if (fs.existsSync(pkg)) {
+      return dir;
+    }
+    const parent = path.dirname(dir);
+    if (parent === dir) throw new Error(`Could not find package.json above ${startFile}`);
+    dir = parent;
+  }
+}
+
+/**
+ * Resolve transitive dependencies of specified packages. Useful when using pnpm because
+ * it does not hoist dependencies to the top-level node_modules.
+ *
+ * @param {string[]} pkgs
+ * @returns {import('vite').Plugin}
+ */
+export default function VitePluginPnpmResolve(pkgs = ['@apostrophecms/vite', 'apostrophe']) {
+  const roots = pkgs.map((name) => findPkgRoot(require.resolve(name)));
+
+  return {
+    name: 'apos-pnpm-resolve',
+    enforce: 'pre',
+    async resolveId(source, importer, options) {
+      // Let vite/rollup try first
+      const resolved = await this.resolve(source, importer, { ...options, skipSelf: true });
+      if (resolved) return resolved;
+
+      // Ignore URLs, virtual ids, and relative paths
+      if (!/^[\w@][^:]*$/.test(source) || source.startsWith('.') || source.startsWith('/')) {
+        return null;
+      }
+
+      // Fallback: resolve as if from each package's install dir
+      for (const root of roots) {
+        try {
+          const id = require.resolve(source, { paths: [root] });
+          return id;
+        } catch { /* continue */ }
+      }
+      return null;
+    }
+  };
+}


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## Summary

In `pnpm`, unlike other package managers, by default dependencies are not hoisted to the highest `node_modules` folder possible. As a result, on `pnpm` the admin UI is unable to build; the copied source in the `apos-build` folder is not able to resolve its transitive dependencies.

This PR adds a plugin that helps module resolution in a `pnpm` context. Given a list of direct dependency packages, it searches those packages' dependencies as needed. This should be a no-op outside `pnpm` because vite and rollup get a chance to resolve the module first; hoisted dependencies will always be found before this plugin searches elsewhere.

## What are the specific steps to test this change?

1. Run the backend and ensure the build succeeds (especially the admin UI build) when running with `pnpm`.

## What kind of change does this PR introduce?

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [x] Build-related changes
- [ ] Other

## Make sure the PR fulfills these requirements:

- [x] It includes a) the existing issue ID being resolved, b) a convincing reason for adding this feature, or c) a clear description of the bug it resolves
- [ ] The changelog is updated
- [ ] Related documentation has been updated
- [ ] Related tests have been updated

**Other information:**
- Please provide guidance on what version this change should be a part of so I can update the changelog accordingly.
- I wasn't sure what documentation should be updated for this change, let me know of any suggestions.
- The existing tests pass and I think setting up a pnpm context for a test would be a big lift, but let me know if you feel that's necessary.